### PR TITLE
Separate including dependencies and running in topological order (Major)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Commands
 
     --include-deps    runs scripts on all dependencies before the filtered packages
 
+    --ordered         runs scripts on packages in topological order
+
   exec <command>      run a shell command in each packages
 
     --filter          all: (default) all packages
@@ -69,6 +71,8 @@ Commands
     --grep            only packages which name matches the given glob pattern
 
     --include-deps    runs the shell command on all dependencies before the filtered packages
+
+    --ordered         runs the shell command on packages in topological order
 
   write               synchronizes to the cache
 
@@ -87,14 +91,16 @@ Examples
   workspace-cache list --hierarchy root
   workspace-cache list --hierarchy root --grep "@common/*"
 
-  workspace-cache run build --include-deps
-  workspace-cache run build --include-deps --filter not-cached
+  workspace-cache run build --ordered
+  workspace-cache run build --ordered --filter not-cached
   workspace-cache run test --hierarchy root
   workspace-cache run test -- -i
   workspace-cache run test --grep "*streams"
+  workspace-cache run test --include-deps --grep "*stream"
 
   workspace-cache exec ls
   workspace-cache exec -- ls -l
+  workspace-cache exec --ordered -- make
 
   workspace-cache write
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -44,6 +44,8 @@ Commands
 
     --include-deps    runs scripts on all dependencies before the filtered packages
 
+    --ordered         runs scripts on packages in topological order
+
   exec <command>      run a shell command in each packages
 
     --filter          all: (default) all packages
@@ -57,6 +59,8 @@ Commands
     --grep            only packages which name matches the given glob pattern
 
     --include-deps    runs the shell command on all dependencies before the filtered packages
+
+    --ordered         runs the shell command on packages in topological order
 
   write               synchronizes to the cache
 
@@ -75,14 +79,16 @@ Examples
   workspace-cache list --hierarchy root
   workspace-cache list --hierarchy root --grep "@common/*"
 
-  workspace-cache run build --include-deps
-  workspace-cache run build --include-deps --filter not-cached
+  workspace-cache run build --ordered
+  workspace-cache run build --ordered --filter not-cached
   workspace-cache run test --hierarchy root
   workspace-cache run test -- -i
   workspace-cache run test --grep "*streams"
+  workspace-cache run test --include-deps --grep "*stream"
 
   workspace-cache exec ls
   workspace-cache exec -- ls -l
+  workspace-cache exec --ordered -- make
 
   workspace-cache write
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,9 +116,9 @@ const main = async (cwd, cache, command, args, options) => {
         ),
         run: pipeline(
           filterPackages(options),
-          chose(options.includeDeps ? "includeDeps" : "normal", {
-            includeDeps: pipeline(
-              includeDependencies(),
+          when(options.includeDeps, includeDependencies()),
+          chose(Boolean(options.ordered), {
+            true: pipeline(
               filterPackagesWithScript(args[0]),
               sortBy("level:desc"),
               partitionBy("level"),
@@ -129,7 +129,7 @@ const main = async (cwd, cache, command, args, options) => {
                 })
               )
             ),
-            normal: pipeline(
+            false: pipeline(
               filterPackagesWithScript(args[0]),
               execute({
                 command: `${npmClient} run ${args.join(" ")}`,
@@ -140,14 +140,14 @@ const main = async (cwd, cache, command, args, options) => {
         ),
         exec: pipeline(
           filterPackages(options),
-          chose(options.includeDeps ? "includeDeps" : "normal", {
-            includeDeps: pipeline(
-              includeDependencies(),
+          when(options.includeDeps, includeDependencies()),
+          chose(Boolean(options.ordered), {
+            true: pipeline(
               sortBy("level:desc"),
               partitionBy("level"),
               withGroup(execute({ command: args.join(" "), concurrency }))
             ),
-            normal: execute({ command: args.join(" "), concurrency }),
+            false: execute({ command: args.join(" "), concurrency }),
           })
         ),
         read: pipeline(

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "preversion": "npm run lint"
   },
   "dependencies": {
-    "@transformation/core": "^1.30.2",
-    "@transformation/glob": "^1.30.2",
+    "@transformation/core": "^1.32.0",
+    "@transformation/glob": "^1.32.0",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",
     "delete-empty": "3.0.0",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -359,6 +359,31 @@ describe("workspace-cache", () => {
 
       it("includes all of the dependencies with the given script of the filtered packages", () => {
         expect(getOutputs(), "to equal", [
+          "app-a: yarn run hello",
+          "package-c: yarn run hello",
+        ]);
+      });
+    });
+
+    describe("with --ordered", () => {
+      beforeEach(async () => {
+        mockIO.start();
+        try {
+          await main(cwd, cacheWithPartialCascadingChange, "run", ["hello"], {
+            concurrency: 1,
+            filter: "all",
+            hierarchy: "all",
+            grep: "app-a",
+            includeDeps: true,
+            ordered: true,
+          });
+        } finally {
+          result = mockIO.end();
+        }
+      });
+
+      it("runs scripts on packages in topological order", () => {
+        expect(getOutputs(), "to equal", [
           "package-c: yarn run hello",
           "app-a: yarn run hello",
         ]);
@@ -446,6 +471,32 @@ describe("workspace-cache", () => {
       });
 
       it("includes all of the dependencies with the given script of the filtered packages", () => {
+        expect(getOutputs(), "to equal", [
+          "app-a: ls",
+          "package-a: ls",
+          "package-c: ls",
+        ]);
+      });
+    });
+
+    describe("with --ordered", () => {
+      beforeEach(async () => {
+        mockIO.start();
+        try {
+          await main(cwd, cacheWithPartialCascadingChange, "exec", ["ls"], {
+            concurrency: 1,
+            filter: "all",
+            hierarchy: "all",
+            grep: "app-a",
+            includeDeps: true,
+            ordered: true,
+          });
+        } finally {
+          result = mockIO.end();
+        }
+      });
+
+      it("runs scripts on packages in topological order", () => {
         expect(getOutputs(), "to equal", [
           "package-c: ls",
           "package-a: ls",


### PR DESCRIPTION
Including dependencies is usually only something you will do when grepping, but running in topological order in almost always what you want when running build scripts.

Breaking:

If you were relying on the ordering when using `--include-deps` you need to also add the `--ordered` flag now. 