### PR TITLE
Support listing packages as JSON objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## workspace-cache 
+## workspace-cache
 
 [![Build Status](https://travis-ci.org/sunesimonsen/workspace-cache.svg?branch=master)](https://travis-ci.org/sunesimonsen/workspace-cache)
 
@@ -11,7 +11,7 @@ based on the individual files in each package.
 
 ## Installation
 
-``` sh
+```sh
 npm install workspace-cache
 ```
 
@@ -43,6 +43,8 @@ Commands
     --grep            only packages which name matches the given glob pattern
 
     --include-deps    include the dependencies for all of the matching packages
+
+    --json            output JSON objects
 
   run <script>        run a npm script in each packages that contains that script
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -32,6 +32,8 @@ Commands
 
     --include-deps    include the dependencies for all of the matching packages
 
+    --json            output JSON objects
+
   run <script>        run a npm script in each packages that contains that script
 
     --filter          all: (default) all packages

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,12 @@ const main = async (cwd, cache, command, args, options) => {
           filterPackages(options),
           when(options.includeDeps, includeDependencies()),
           sortBy("order:desc"),
-          tap(({ name }) => name)
+          chose(Boolean(options.json), {
+            true: tap(({ name, path: pathName, localDependencies }) =>
+              JSON.stringify({ name, path: path.relative(cwd, pathName) })
+            ),
+            false: tap(({ name }) => name),
+          })
         ),
         run: pipeline(
           filterPackages(options),

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -283,6 +283,7 @@ describe("workspace-cache", () => {
         });
       });
     });
+
     describe("--filter cached --hierarchy shared", () => {
       beforeEach(async () => {
         await main(cwd, cacheWithPartialCascadingChange, "list", [], {
@@ -296,6 +297,28 @@ describe("workspace-cache", () => {
         expect(console.log, "to have calls satisfying", () => {
           console.log("package-c");
           console.log("package-a");
+        });
+      });
+    });
+
+    describe("--filter cached --hierarchy shared --json", () => {
+      beforeEach(async () => {
+        await main(cwd, cacheWithPartialCascadingChange, "list", [], {
+          concurrency: 1,
+          filter: "cached",
+          hierarchy: "shared",
+          json: true,
+        });
+      });
+
+      it("prints the shared and cached packages", () => {
+        expect(console.log, "to have calls satisfying", () => {
+          console.log(
+            `{"name":"package-c","path":"packages/package-c/package.json"}`
+          );
+          console.log(
+            `{"name":"package-a","path":"packages/package-a/package.json"}`
+          );
         });
       });
     });


### PR DESCRIPTION
Adds a JSON output option to list:

```
[repo]$ workspace-cache list --include-deps --ordered --json 
{"name":"package-c","path":"packages/package-c/package.json"}
{"name":"package-b","path":"packages/package-b/package.json"}
{"name":"package-a","path":"packages/package-a/package.json"}
{"name":"app-b","path":"apps/app-b/package.json"}
{"name":"app-a","path":"apps/app-a/package.json"}
```