### PR TITLE
Fix topological sort

### DIFF
--- a/lib/groupTopological.js
+++ b/lib/groupTopological.js
@@ -1,8 +1,9 @@
 const {
-  Group,
   filter,
   flatMap,
+  groupBy,
   pipeline,
+  sortBy,
   toArray,
 } = require("@transformation/core");
 
@@ -11,20 +12,18 @@ const groupTopological = () =>
     filter((p) => p.hierarchy === "root"),
     toArray(),
     flatMap((packages) => {
-      const levels = [];
       let workQueue = packages;
       const seen = new Set();
-      let order = 0;
       let level = 0;
 
+      // Assign a topological level to each package
       while (workQueue.length > 0) {
         const newWork = [];
 
-        const nextLevel = [];
         for (const p of workQueue) {
+          p.level = Math.max(level, p.level || 0);
           if (!seen.has(p)) {
             seen.add(p);
-            nextLevel.push(p);
 
             for (const d of p.localDependencies) {
               newWork.push(d);
@@ -32,26 +31,14 @@ const groupTopological = () =>
           }
         }
 
-        nextLevel.sort((a, b) => {
-          if (a.name < b.name) return -1;
-          if (a.name > b.name) return 1;
-          return 0;
-        });
-
-        for (const p of nextLevel) {
-          p.order = order++;
-          p.level = level;
-        }
-
-        levels.push(nextLevel);
         workQueue = newWork;
         level++;
       }
 
-      return levels
-        .map((level, i) => Group.create({ key: `level-${i}`, items: level }))
-        .reverse();
-    })
+      return Array.from(seen);
+    }),
+    sortBy("level:desc"),
+    groupBy(({ level }) => `level-${level}`)
   );
 
 module.exports = groupTopological;

--- a/lib/includeDependencies.js
+++ b/lib/includeDependencies.js
@@ -1,14 +1,9 @@
-const {
-  map,
-  pipeline,
-  splitIterable,
-  toArray,
-} = require("@transformation/core");
+const { pipeline, flatMap, toArray } = require("@transformation/core");
 
 const includeDependencies = () =>
   pipeline(
     toArray(),
-    map((packages) => {
+    flatMap((packages) => {
       const withDependencies = [];
       const seen = new Set();
       let workQuery = packages;
@@ -24,8 +19,7 @@ const includeDependencies = () =>
         workQuery = newWork;
       }
       return withDependencies;
-    }),
-    splitIterable()
+    })
   );
 
 module.exports = includeDependencies;

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,7 @@ const main = async (cwd, cache, command, args, options) => {
           chose(Boolean(options.ordered), {
             true: pipeline(
               filterPackagesWithScript(args[0]),
-              sortBy("level:desc", "name:desc"),
+              sortBy("level:desc", "name"),
               partitionBy("level"),
               withGroup(
                 execute({
@@ -137,7 +137,7 @@ const main = async (cwd, cache, command, args, options) => {
             ),
             false: pipeline(
               filterPackagesWithScript(args[0]),
-              sortBy("level:desc", "name:desc"),
+              sortBy("level:desc", "name"),
               execute({
                 command: `${npmClient} run ${args.join(" ")}`,
                 concurrency,
@@ -150,12 +150,12 @@ const main = async (cwd, cache, command, args, options) => {
           when(options.includeDeps, includeDependencies()),
           chose(Boolean(options.ordered), {
             true: pipeline(
-              sortBy("level:desc", "name:desc"),
+              sortBy("level:desc", "name"),
               partitionBy("level"),
               withGroup(execute({ command: args.join(" "), concurrency }))
             ),
             false: pipeline(
-              sortBy("level:desc", "name:desc"),
+              sortBy("level:desc", "name"),
               execute({ command: args.join(" "), concurrency })
             ),
           })

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,7 @@ const main = async (cwd, cache, command, args, options) => {
         list: pipeline(
           filterPackages(options),
           when(options.includeDeps, includeDependencies()),
-          sortBy("order:desc"),
+          sortBy("level:desc", "name:desc"),
           chose(Boolean(options.json), {
             true: jsonOutput({ cwd }),
             false: tap(({ name }) => name),
@@ -126,7 +126,7 @@ const main = async (cwd, cache, command, args, options) => {
           chose(Boolean(options.ordered), {
             true: pipeline(
               filterPackagesWithScript(args[0]),
-              sortBy("level:desc"),
+              sortBy("level:desc", "name:desc"),
               partitionBy("level"),
               withGroup(
                 execute({
@@ -137,7 +137,7 @@ const main = async (cwd, cache, command, args, options) => {
             ),
             false: pipeline(
               filterPackagesWithScript(args[0]),
-              sortBy("order:desc"),
+              sortBy("level:desc", "name:desc"),
               execute({
                 command: `${npmClient} run ${args.join(" ")}`,
                 concurrency,
@@ -150,12 +150,12 @@ const main = async (cwd, cache, command, args, options) => {
           when(options.includeDeps, includeDependencies()),
           chose(Boolean(options.ordered), {
             true: pipeline(
-              sortBy("level:desc"),
+              sortBy("level:desc", "name:desc"),
               partitionBy("level"),
               withGroup(execute({ command: args.join(" "), concurrency }))
             ),
             false: pipeline(
-              sortBy("order:desc"),
+              sortBy("level:desc", "name:desc"),
               execute({ command: args.join(" "), concurrency })
             ),
           })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -360,8 +360,8 @@ describe("workspace-cache", () => {
         expect(getOutputs(), "to equal", [
           "package-c: yarn run hello",
           "package-b: yarn run hello",
-          "app-b: yarn run hello",
           "app-a: yarn run hello",
+          "app-b: yarn run hello",
         ]);
       });
     });
@@ -383,8 +383,8 @@ describe("workspace-cache", () => {
 
       it("honors the filtering", () => {
         expect(getOutputs(), "to equal", [
-          "app-b: yarn run hello",
           "app-a: yarn run hello",
+          "app-b: yarn run hello",
         ]);
       });
     });
@@ -474,10 +474,10 @@ describe("workspace-cache", () => {
       it("runs the script in all packages with that script", () => {
         expect(getOutputs(), "to equal", [
           "package-c: ls",
-          "package-b: ls",
           "package-a: ls",
-          "app-b: ls",
+          "package-b: ls",
           "app-a: ls",
+          "app-b: ls",
         ]);
       });
     });
@@ -498,7 +498,7 @@ describe("workspace-cache", () => {
       });
 
       it("honors the filtering", () => {
-        expect(getOutputs(), "to equal", ["app-b: ls", "app-a: ls"]);
+        expect(getOutputs(), "to equal", ["app-a: ls", "app-b: ls"]);
       });
     });
 

--- a/test/topologicalSort.spec.js
+++ b/test/topologicalSort.spec.js
@@ -1,0 +1,25 @@
+const { program, emitAll, forEach } = require("@transformation/core");
+const sortTopological = require("../lib/sortTopological");
+const expect = require("unexpected");
+
+describe("sortTopological", () => {
+  it("sorts packages in topological order", async () => {
+    const f = { name: "f", hierarchy: "shared", localDependencies: [] };
+    const e = { name: "e", hierarchy: "shared", localDependencies: [f] };
+    const d = { name: "d", hierarchy: "shared", localDependencies: [e] };
+    const c = { name: "c", hierarchy: "shared", localDependencies: [] };
+    const b = { name: "b", hierarchy: "shared", localDependencies: [c, f] };
+    const a = { name: "a", hierarchy: "root", localDependencies: [b, c, d] };
+    const packages = [a, b, c, d, e, f];
+
+    const result = [];
+
+    await program(
+      emitAll(packages),
+      sortTopological(),
+      forEach((v) => result.push(v))
+    );
+
+    expect(result, "to satisfy", [f, c, e, b, d, a]);
+  });
+});


### PR DESCRIPTION
For cases where you have the following dependency structure would calculate the topological levels incorrectly:

```
A -> C
A -> B -> C
```

The problem were that C would get the level of 1 instead of 2, that means B and C would be executed in parallel, which obviously is incorrect.

The tests unfortunately didn't catch this case as the sorting of the packages happen to yield the correct result accidentally 😵‍💫