### PR TITLE
Detect circular dependencies

### DIFF
--- a/lib/calculatePackageHash.js
+++ b/lib/calculatePackageHash.js
@@ -1,7 +1,11 @@
 const crypto = require("crypto");
 const mem = require("mem");
 
-const calculatePackageHash = mem((p) => {
+const calculatePackageHash = mem((p, seen = new Set()) => {
+  if (seen.has(p.name)) {
+    throw new Error(`Circular dependencies involving ${p.name}`);
+  }
+  seen.add(p.name);
   const hash = crypto.createHash("sha256");
   hash.update(p.filesHash);
   for (const dependency of p.localDependencies) {

--- a/lib/calculatePackageHash.js
+++ b/lib/calculatePackageHash.js
@@ -1,15 +1,26 @@
 const crypto = require("crypto");
 const mem = require("mem");
 
+const findCircularDependencyLoop = (p, seen = new Set(), path = []) => {
+  if (seen.has(p.name)) {
+    path.push(p.name);
+    throw new Error(`Circular dependencies: ${path.join(" -> ")}`);
+  }
+  seen.add(p.name);
+  for (const dependency of p.localDependencies) {
+    findCircularDependencyLoop(dependency, seen, [...path, p.name]);
+  }
+};
+
 const calculatePackageHash = mem((p, seen = new Set()) => {
   if (seen.has(p.name)) {
-    throw new Error(`Circular dependencies involving ${p.name}`);
+    findCircularDependencyLoop(p);
   }
   seen.add(p.name);
   const hash = crypto.createHash("sha256");
   hash.update(p.filesHash);
   for (const dependency of p.localDependencies) {
-    const dependencyHash = calculatePackageHash(dependency);
+    const dependencyHash = calculatePackageHash(dependency, seen);
     hash.update(dependencyHash);
   }
   return hash.digest("hex");

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ const main = async (cwd, cache, command, args, options) => {
       }),
       addLocalDependencies(),
       sortTopological(),
-      extend({ hash: map(calculatePackageHash) }),
+      extend({ hash: map((p) => calculatePackageHash(p)) }),
       extend({
         cacheDir: map((p) => path.join(cacheDir, p.name, p.hash)),
       }),

--- a/test/calculatePageHash.spec.js
+++ b/test/calculatePageHash.spec.js
@@ -1,0 +1,69 @@
+const calculatePackageHash = require("../lib/calculatePackageHash");
+const expect = require("unexpected");
+
+describe("calculatePackageHash", () => {
+  describe("on a regular dependency tree", () => {
+    const d = {
+      name: "d",
+      filesHash: "d",
+      localDependencies: [],
+    };
+    const c = {
+      name: "c",
+      filesHash: "c",
+      localDependencies: [d],
+    };
+    const b = {
+      name: "b",
+      filesHash: "b",
+      localDependencies: [c, d],
+    };
+    const a = {
+      name: "a",
+      filesHash: "a",
+      localDependencies: [b, d],
+    };
+
+    it("returns the combined hash of the dependencies", () => {
+      const hash = calculatePackageHash(a);
+      expect(
+        hash,
+        "to equal",
+        "a17dda3f5b5eeb90988400a380f763a87050baba91e3ddedeb6fa747e2ea500b"
+      );
+    });
+  });
+
+  describe("on a circular dependency tree", () => {
+    const d = {
+      name: "d",
+      filesHash: "d",
+      localDependencies: [],
+    };
+    const c = {
+      name: "c",
+      filesHash: "c",
+      localDependencies: [d],
+    };
+    const b = {
+      name: "b",
+      filesHash: "b",
+      localDependencies: [c, d],
+    };
+    const a = {
+      name: "a",
+      filesHash: "a",
+      localDependencies: [b, d],
+    };
+
+    c.localDependencies.push(a);
+
+    it("throw a circular dependencies error", () => {
+      expect(
+        () => calculatePackageHash(a),
+        "to throw",
+        "Circular dependencies: a -> b -> c -> a"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Throw an error like this:

```
Circular dependencies: a -> b -> c -> a
```